### PR TITLE
feat: 카카오맵 API 연동 및 적용

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local
@@ -21,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
+        "axios": "^1.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
@@ -5021,6 +5022,29 @@
       "integrity": "sha512-lCZN5XRuOnpG4bpMq8v0khrWtUOn+i8lZSb6wHZH56ZfbIEv6XwJV84AAueh9/zi7qPVJ/E4yz6fmsiyOmXR4w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -13933,6 +13957,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -20689,6 +20718,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.1.tgz",
       "integrity": "sha512-lCZN5XRuOnpG4bpMq8v0khrWtUOn+i8lZSb6wHZH56ZfbIEv6XwJV84AAueh9/zi7qPVJ/E4yz6fmsiyOmXR4w=="
     },
+    "axios": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -26980,6 +27031,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "axios": "^1.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -40,4 +40,6 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_API_KEY%&libraries=services"></script>
+
 </html>

--- a/client/src/apis/user.js
+++ b/client/src/apis/user.js
@@ -5,8 +5,8 @@ const origin = "http://20.214.190.113:5050";
 const getUserURL = origin + "/test/users/";
 
 // Test API Request
-export const getUser = async(user)=>{
-    const requestURL = getUserURL + user
+export const getUser = async(userId)=>{
+    const requestURL = getUserURL + userId
 
     const user = await axios.get(requestURL)
     .then(res=>res.data)

--- a/client/src/assets/css/map.css
+++ b/client/src/assets/css/map.css
@@ -1,0 +1,77 @@
+* {
+    box-sizing: border-box;
+}
+
+ul {
+    margin : 0;
+    padding: 0;
+}
+
+/* 검색창 */
+.map-wrap {
+    width: 600px;
+}
+
+.map-search {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-bottom: 0.5rem;
+}
+
+.map-searchbar-wrap{
+    border: 1px solid #ebebeb;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.map-search .map-searchbar, .map-searchbar-wrap button {
+    padding: 0.5rem 0.5rem;
+    border: none;
+    font-size: 1rem;
+    flex-shrink: 1;
+}
+
+.map-search .map-searchbar {
+    width: 70%;
+    border-right: 0px;
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+}
+
+.map-searchbar-wrap button{
+    width: 30%;
+    border-left: 0px;
+    font-weight: 700;
+}
+
+.map-searchbar-wrap button:hover{
+    cursor: pointer;
+}
+
+/* 검색 결과 리스트 */
+.place-list {
+    z-index:10;
+    border: 1px solid #ebebeb;
+    border-radius: 0.5rem;
+    margin-top : 0.5rem;
+    overflow: hidden;
+}
+
+.place-list .place-list-item{
+    padding: 0.4rem 1rem;
+    border-bottom: solid 1px #ebebeb;
+}
+
+.place-list .place-list-item:last-child{
+    border-bottom: none;
+}
+
+.place-list .place-list-item:hover{
+    cursor: pointer;
+    background-color: #ebebeb;
+}
+
+.place-list .place-list-item .address{
+    margin-left: 1rem;
+}

--- a/client/src/components/Map/KakaoMap.js
+++ b/client/src/components/Map/KakaoMap.js
@@ -1,0 +1,74 @@
+// modules
+import React, {useEffect, useState} from "react";
+
+// components
+import PlaceList from "./PlaceList";
+import PlaceListPagination from "./PlaceListPagination";
+
+// css
+import "../../assets/css/map.css";
+
+// hooks
+import usePlaces from "../../hooks/usePlaces";
+import useMap from "../../hooks/useMap";
+
+const {kakao} = window;
+
+const KakaoMap = ()=>{
+    const map = useMap();
+    const search = usePlaces();
+
+    const [keyword, setKeyword] = useState("");
+    const [places, setPlaces] = useState(null)
+    const [pagination, setPagination] = useState(null);
+
+    const searchRequest = ()=>{
+        if (keyword.length === 0) return;
+        search.keywordSearch(keyword, (result, status, pagination)=>{
+            console.log(result);
+            console.log(status);
+            console.log(pagination);
+            setPlaces(result);
+            setPagination(pagination);
+        },{})
+    }
+    
+    const searchBtnHandler = ()=>{
+        searchRequest();
+    }
+
+    const searchEnterHandler = (e)=>{
+        if(e.key === "Enter") searchRequest();
+    }
+
+    return (
+        <div className="map-wrap">
+            <div className="map-search">
+                <div className="map-searchbar-wrap">
+                    <input className="map-searchbar" 
+                        value={keyword} 
+                        onChange={(e)=>{setKeyword(e.target.value)}} 
+                        onKeyUp={searchEnterHandler}
+                        size="15" 
+                        placeholder="장소명을 입력해주세요."/> 
+                    <button onClick={searchBtnHandler}>검색하기</button> 
+                </div>
+                {places?
+                    <>
+                    <PlaceList places={places} map={map}/>
+                    </> 
+                    : <></>
+                }
+            </div>
+            <div id="map" style={{
+                width:"600px",
+                height:"400px",
+                position:"relative",
+                overflow:"hidden"
+                }}>
+            </div>
+        </div>
+    )
+}
+
+export default KakaoMap;

--- a/client/src/components/Map/PlaceList.js
+++ b/client/src/components/Map/PlaceList.js
@@ -1,0 +1,20 @@
+// modules
+import React, {useState, useEffect} from "react";
+
+// components
+import PlaceListItem from "./PlaceListItem";
+
+const PlaceList = ({places, map})=>{
+
+    return (
+        <ul className="place-list">
+            {
+                places.map((place, idx)=>{
+                    return <PlaceListItem key={idx} place={place} map={map}/>
+                })
+            }
+        </ul>
+    )
+}
+
+export default PlaceList;

--- a/client/src/components/Map/PlaceListItem.js
+++ b/client/src/components/Map/PlaceListItem.js
@@ -1,0 +1,29 @@
+// modules
+import {useState} from "react";
+
+const {kakao} = window
+
+const PlaceListItem = ({place, map})=>{
+    const [placeId, setPlaceId] = useState(place.id);
+    const position = new kakao.maps.LatLng(place.y, place.x);
+    const marker = new kakao.maps.Marker({position});
+    
+
+    const itemEnterHandler= ()=>{
+        marker.setMap(map);
+        map.panTo(position);
+    }
+
+    const itemClickHandler = ()=>{
+        console.log(place);
+    }
+
+    return (
+        <div className="place-list-item" onMouseEnter={itemEnterHandler} onClick={itemClickHandler}>
+            <span className="name">{place.place_name}</span>
+            <span className="address">{place.address_name}</span>
+        </div>
+    )
+}
+
+export default PlaceListItem;

--- a/client/src/components/Map/PlaceListPagination.js
+++ b/client/src/components/Map/PlaceListPagination.js
@@ -1,0 +1,17 @@
+//module
+
+const PlaceListPagination = ({pagination})=>{
+    const current = pagination.current;
+    const pageNums = [];
+    if (current.hasPrevPage) pageNums.push(current - 1);
+    pageNums.push(current);
+    if (current.hasNextPage) pageNums.push(current + 1);
+
+    return (
+        <ul>
+            {pageNums.map(num=>{return <li keys={num}>{num}</li>})}
+        </ul>
+    )
+}
+
+export default PlaceListPagination

--- a/client/src/hooks/useMap.js
+++ b/client/src/hooks/useMap.js
@@ -1,0 +1,24 @@
+// modules
+import {useState, useEffect} from "react";
+
+const {kakao} = window;
+
+const useMap = ()=>{
+    const [map, setMap] = useState(null);
+
+    useEffect(()=>{
+        if(!kakao) return;
+
+        const container = document.getElementById("map");
+        if(!container) return;
+        
+        const options = { center: new kakao.maps.LatLng(33.450701, 126.570667) };
+        const kakaoMap = new kakao.maps.Map(container, options);
+        
+        setMap(kakaoMap);
+    }, [])
+
+    return map;
+}
+
+export default useMap;

--- a/client/src/hooks/usePlaces.js
+++ b/client/src/hooks/usePlaces.js
@@ -1,0 +1,19 @@
+// modules
+import {useState, useEffect} from "react";
+
+const {kakao} = window;
+
+const usePlaces = ()=>{
+    const [places, setPlaces] = useState(null);
+
+    useEffect(()=>{
+        const kakaoPlaces = new kakao.maps.services.Places();
+
+        setPlaces(kakaoPlaces);
+    }, [])
+
+    return places
+}
+
+export default usePlaces;
+


### PR DESCRIPTION
카카오맵을 통해서 특정장소를 검색하고 지도에서 확인.
리뷰하는 맛집에 대한 정보를 다른 사람들과 통일시킬 수 있게 해당 맛집의  ID를 가져오게끔 구현되었습니다.
현재 검색 결과 페이지네이션을 제외했습니다. 추후에 기능 추가 예정입니다.