### PR TITLE
Pagination

### DIFF
--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -59,14 +59,9 @@ const Pagination = ({props,user}) => {
         }
     },[page,limit, props,user.id, searchData])
 
-
-    // useEffect(()=>{
-    //     const numMapping =(e) => {
-    //     }
-    //     numMapping()
-    // },[])
-
-
+    useEffect(()=>{
+        setPage(1)
+    },[searchData])
 
     return(
 


### PR DESCRIPTION
페이지 넘긴 후 써치를 하면 해당 페이지에 머무르는 탓에 
검색결과가 바로 보이지 않는 문제가 있었습니다. 수정 후 커밋합니다.