### PR TITLE
MyPage NFTs Error Resolved

### DIFF
--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -32,11 +32,12 @@ const Pagination = ({props,user}) => {
 
     let numPages =()=>{
         if(pagination!==null && pagination!==undefined) {
+            console.log(pagination)
             let num = Math.ceil(pagination.totalNum.totalNum/limit)
-            if(!isNaN(num)) {
-                return num
+            if(props==='nft') {
+                return Math.ceil(pagination.totalNum[0].totalNum/limit)
             }else{
-                return 1
+                return num
             }
         }
     }


### PR DESCRIPTION
특정 유저 아이디의 NFT 데이터에서 문제가 있었습니다.
<img width="454" alt="image" src="https://user-images.githubusercontent.com/113079895/212218433-de976ce4-b234-4e7a-9908-36e97b0a192a.png">
다른 데이터는 totalNum.totalNum 에 값이 들어 있는 반면,
특정 유저 아이디의 NFT는 배열로 되어있어, totalNum[0].totalNum 로 접근이 가능했습니다.
하여 조건문으로 특정 유저 아이디의 NFT 데이터를 선별하여 처리하도록 작업하여 커밋합니다.